### PR TITLE
Adapted to Xcode 16.4

### DIFF
--- a/Sources/PCLBlurEffectAlert+Controller.swift
+++ b/Sources/PCLBlurEffectAlert+Controller.swift
@@ -815,7 +815,7 @@ private extension PCLBlurEffectAlertController {
         alertViewHeightConstraint.constant = alertViewHeight
         view.layoutIfNeeded()
     }
-    dynamic func buttonWasTouchUpInside(_ sender: UIButton) {
+    @objc dynamic func buttonWasTouchUpInside(_ sender: UIButton) {
         sender.isSelected = true
         let action = actions[sender.tag]
         dismiss(animated: true) {
@@ -846,7 +846,7 @@ extension PCLBlurEffectAlertController : PCLAlertKeyboardNotificationObserver, P
     }
     func keyboardWillShow(_ notification: Notification) {
         guard let userInfo = notification.userInfo as? [String: AnyObject],
-            let keyboardSize = userInfo[UIKeyboardFrameEndUserInfoKey]?.cgRectValue.size else {
+              let keyboardSize = userInfo[UIResponder.keyboardFrameEndUserInfoKey]?.cgRectValue.size else {
                 return
         }
         keyboardHeight = keyboardSize.height

--- a/Sources/PCLBlurEffectAlert+TransitionAnimator.swift
+++ b/Sources/PCLBlurEffectAlert+TransitionAnimator.swift
@@ -99,7 +99,7 @@ private extension PCLBlurEffectAlert.TransitionAnimator {
                 alertController.cornerView.subviews.forEach { $0.alpha = 0 }
             }
         }
-        UIView.animate(withDuration: transitionDuration(using: transitionContext), delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: UIViewAnimationOptions(), animations: animations) { finished in
+        UIView.animate(withDuration: transitionDuration(using: transitionContext), delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: UIView.AnimationOptions(), animations: animations) { finished in
             guard finished else { return }
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }

--- a/Sources/PCLBlurEffectAlert.swift
+++ b/Sources/PCLBlurEffectAlert.swift
@@ -38,7 +38,7 @@ extension PCLBlurEffectAlert {
 }
 
 // MARK: - PCLRespondsViewDelegate
-protocol PCLRespondsViewDelegate: class {
+protocol PCLRespondsViewDelegate: AnyObject {
     func respondsViewDidTouch(_ view: UIView)
 }
 
@@ -51,7 +51,7 @@ extension PCLBlurEffectAlert {
 }
 
 // MARK: - keyboardWillShow/Hide
-@objc protocol PCLAlertKeyboardNotificationObserver: class {
+@objc protocol PCLAlertKeyboardNotificationObserver: AnyObject {
     func keyboardWillShow(_ notification: Notification)
     func keyboardWillHide(_ notification: Notification)
 }
@@ -60,34 +60,34 @@ extension PCLBlurEffectAlert.NotificationManager {
     func addKeyboardNotificationObserver(_ observer: PCLAlertKeyboardNotificationObserver) {
         notificationCenter.addObserver(observer,
                                        selector: #selector(PCLAlertKeyboardNotificationObserver.keyboardWillShow(_:)),
-                                       name: Notification.Name.UIKeyboardWillShow,
+                                       name: UIResponder.keyboardWillShowNotification,
                                        object: nil)
         notificationCenter.addObserver(observer,
                                        selector: #selector(PCLAlertKeyboardNotificationObserver.keyboardWillHide(_:)),
-                                       name: Notification.Name.UIKeyboardWillHide,
+                                       name: UIResponder.keyboardWillHideNotification,
                                        object: nil)
     }
     func removeKeyboardNotificationObserver(_ observer: PCLAlertKeyboardNotificationObserver) {
         notificationCenter.removeObserver(observer,
-                                          name: Notification.Name.UIKeyboardWillShow,
+                                          name: UIResponder.keyboardWillShowNotification,
                                           object: nil)
         notificationCenter.removeObserver(observer,
-                                          name: Notification.Name.UIKeyboardWillHide,
+                                          name: UIResponder.keyboardWillHideNotification,
                                           object: nil)
     }
     func postKeyboardWillShowNotification() {
-        notificationCenter.post(Notification(name: Notification.Name.UIKeyboardWillShow,
+        notificationCenter.post(Notification(name: UIResponder.keyboardWillShowNotification,
                                              object: nil))
     }
     func postKeyboardWillHideNotification() {
-        notificationCenter.post(Notification(name: Notification.Name.UIKeyboardWillHide,
+        notificationCenter.post(Notification(name: UIResponder.keyboardWillHideNotification,
                                              object: nil))
     }
 }
 
 
 // MARK: - AlertActionEnabledDidChange
-@objc protocol PCLAlertActionEnabledDidChangeNotificationObserver: class {
+@objc protocol PCLAlertActionEnabledDidChangeNotificationObserver: AnyObject {
     func alertActionEnabledDidChange(_ notification: Notification)
 }
 // MARK: - private


### PR DESCRIPTION
This PR replaces deprecated Notification.Name.UIKeyboardWillShow with UIResponder.keyboardWillShowNotification to fix build errors in Xcode 16.4 and Swift 5.x.